### PR TITLE
Fix BST iterator hasNext return type

### DIFF
--- a/trees/binarySearchTreeIterator.py
+++ b/trees/binarySearchTreeIterator.py
@@ -35,7 +35,7 @@ class BSTIterator:
             node = node.left
 
     def hasNext(self) -> bool:
-        return self.stack
+        return bool(self.stack)
         
 
 


### PR DESCRIPTION
## Summary
- ensure `BSTIterator.hasNext` returns a boolean

## Testing
- `python -m py_compile trees/binarySearchTreeIterator.py`

------
https://chatgpt.com/codex/tasks/task_e_6885232f0688832f81d279dd94aef2e0